### PR TITLE
Prevent empty/whitespace string for input

### DIFF
--- a/options.js
+++ b/options.js
@@ -34,17 +34,19 @@ function saveUser (event) {
   event.preventDefault()
 
   const newUser = userInput.value
+  
+  if (newUser !== '') {
+    chrome.storage.sync.get(['users'], function (result) {
+      const oldUsers = result.users instanceof Array ? result.users : []
 
-  chrome.storage.sync.get(['users'], function (result) {
-    const oldUsers = result.users instanceof Array ? result.users : []
-
-    chrome.storage.sync.set({
-      users: [...oldUsers, newUser]
-    }, function () {
-      userInput.value = ''
-      listUsers()
+      chrome.storage.sync.set({
+        users: [...oldUsers, newUser]
+      }, function () {
+        userInput.value = ''
+        listUsers()
+      })
     })
-  })
+  }
 }
 
 function deleteUser (event) {

--- a/options.js
+++ b/options.js
@@ -35,14 +35,15 @@ function saveUser (event) {
 
   const newUser = userInput.value
   
-  if (newUser !== '') {
+  userInput.value = ''
+  
+  if (newUser !== '' && /\S/.test(newUser)) {
     chrome.storage.sync.get(['users'], function (result) {
       const oldUsers = result.users instanceof Array ? result.users : []
 
       chrome.storage.sync.set({
         users: [...oldUsers, newUser]
       }, function () {
-        userInput.value = ''
         listUsers()
       })
     })


### PR DESCRIPTION
Change options.js. Prevent empty string and strings which only contain whitespaces for stored. 

If the input was empty and clicked to save, the extension create an empty, undeletable element.